### PR TITLE
必須引数不足時のsystemExitの捕捉処理を追加#8

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,6 +92,10 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.config_file_path:
+        logging.error("設定ファイルへのパスが指定されていません。")
+        sys.exit(1)
+
     logging.info(f"iniファイル: {args.config_file_path}")
     logging.info(f"抽出パターン: {args.file_pattern}")
     if args.tree_output_file_path:
@@ -99,8 +103,11 @@ def main():
     else:
         logging.info("ツリー出力先: 標準出力")
 
-    config = load_config(args.config_file_path)
-    logging.info(f"設定ファイル: {args.config_file_path} を読み込みました。")
+    try:
+        config = load_config(args.config_file_path)
+        logging.info(f"設定ファイル: {args.config_file_path} を読み込みました。")
+    except Exception:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] 設定ファイルへのパスがNoneの時は異常終了すること
- [x] 設定ファイルを読み込めなかった場合も異常終了すること